### PR TITLE
feat: Add Search Box to Standards Page, Allowing for Simple Discovery of Documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,4 @@ gatsby develop
 
 **Note:** It can take anywhere from a few seconds to a few minutes to start the website, but once the website is live, it does [hot reloading](https://www.gatsbyjs.com/docs/reference/local-development/fast-refresh/).
 
-## Create
-On `/create` page, the user can use the in-browser standard editor to create a standard file. On the left pane, the user can type in code. At the same time, on the right pane, a preview of the rendered standard document will appear.
-
-## Search
-The search feature lets users search for standards based on the name, authors, or category of the standard. This feature allows people to quickly access what they are looking for and adds to the maintainability of the entire website in the long term.
-
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -39,4 +39,10 @@ gatsby develop
 
 **Note:** It can take anywhere from a few seconds to a few minutes to start the website, but once the website is live, it does [hot reloading](https://www.gatsbyjs.com/docs/reference/local-development/fast-refresh/).
 
+## Create
+On `/create` page, the user can use the in-browser standard editor to create a standard file. On the left pane, the user can type in code. At the same time, on the right pane, a preview of the rendered standard document will appear.
+
+## Search
+The search feature lets users search for standards based on the name, authors, or category of the standard. This feature allows people to quickly access what they are looking for and adds to the maintainability of the entire website in the long term.
+
 ## Contribute

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -1,0 +1,34 @@
+import * as React from "react"
+
+const Search = ({ searchTerm, setSearchTerm }) => {
+  return (
+    <div class="flex items-center lg:w-[35rem] w-[20rem]">
+      <div class="relative w-full">
+        <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+          <svg
+            aria-hidden="true"
+            class="w-5 h-5 text-gray-500 dark:text-gray-400"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
+              clip-rule="evenodd"
+            ></path>
+          </svg>
+        </div>
+        <input
+          type="text"
+          class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full pl-10 p-2.5  dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+          placeholder="Search Standards by document name, authors, and categories..."
+          value={searchTerm}
+          onChange={event => setSearchTerm(event.target.value)}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default Search

--- a/src/pages/standards.js
+++ b/src/pages/standards.js
@@ -1,24 +1,53 @@
 import * as React from "react"
+import { useState } from "react"
 import { Link } from "gatsby"
 
 import Layout from "../components/layout"
 import Seo from "../components/seo"
 import Standard from "../components/standard"
+import Search from "../components/search"
+
+function filterStandard(standards, searchTerm) {
+  searchTerm = searchTerm.toLowerCase()
+  return standards.filter(standard => {
+    if (searchTerm === "") {
+      return true
+    } else if (standard.title.toString().toLowerCase().includes(searchTerm)) {
+      return true
+    } else if (
+      standard.authors.filter(author =>
+        author.name.toLowerCase().includes(searchTerm)
+      ).length > 0
+    ) {
+      return true
+    } else if (
+      standard.tags.filter(tag => tag.toLowerCase().includes(searchTerm))
+        .length > 0
+    ) {
+      return true
+    } else return false
+  })
+}
 
 function ProgramsPage() {
-
-  let standards = require('../../data/standards.json')
+  let standards = require("../../data/standards.json")
+  const [searchTerm, setSearchTerm] = useState("")
 
   return (
     <Layout>
       <section className="mt-8">
         <div class="mx-auto max-w-screen-xl px-4 py-4">
           <h2 className="font-bold text-4xl mb-4">Standards</h2>
-          <p className="text-xl mb-16 max-w-2xl">Below is a list of all the standards that are stored in the Vault. These standards are labeled with their current status.</p>
-          <div class="grid gap-4 grid-cols-1 md:grid-cols-2">
-            {
-                standards.map(item => Standard(item))
-            }
+          <p className="text-xl mb-3 max-w-2xl">
+            Below is a list of all the standards that are stored in the Vault.
+            These standards are labeled with their current status.
+          </p>
+          <Search
+            searchTerm={searchTerm}
+            setSearchTerm={setSearchTerm}
+          ></Search>
+          <div class="grid gap-4 grid-cols-1 md:grid-cols-2 mt-6">
+            {filterStandard(standards, searchTerm).map(item => Standard(item))}
           </div>
         </div>
       </section>


### PR DESCRIPTION
# Description
Feat #5 
create a `Search` component that enables searching for standards by their title, authors, and tags(categories). This component is added to the `/standard` page

# Screenshots
When nothing is inputted
<img width="446" alt="no input" src="https://user-images.githubusercontent.com/96609857/209722003-d796c6be-8cfc-4488-a09d-1cc1b982f021.png">
If the title or authors, or tags of a standard contain the search term, it will appear
<img width="440" alt="standard" src="https://user-images.githubusercontent.com/96609857/209722008-c707e26d-8044-4ced-a555-12b8b04dd9df.png">
<img width="575" alt="not included" src="https://user-images.githubusercontent.com/96609857/209722014-09dbba63-9c2a-4626-b81b-4fbed643fe67.png">
