### PR TITLE
chore: add webpack config

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -26,6 +26,7 @@ function slugify(name) {
 /**
  * @type {import('gatsby').GatsbyNode['createPages']}
  */
+
 exports.createPages = ({ actions }) => {
   
   const standards = fs.readdirSync('./standards');
@@ -89,4 +90,12 @@ exports.createPages = ({ actions }) => {
 
   fs.writeFileSync('./data/standards.json', JSON.stringify(standardsFileData, null, 4));
 
+}
+
+exports.onCreateWebpackConfig = ({ actions }) => {
+  actions.setWebpackConfig({
+    node: {
+      fs: 'empty'
+    }
+  })
 }


### PR DESCRIPTION
I ran into the same issue [here](https://github.com/gatsbyjs/gatsby/issues/24815) 
It seems that `fs` is getting bundled up by some packages and these codes add configuration to prevent this from happening. 
